### PR TITLE
【WIP】チャット機能の非同期通信化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,4 +63,5 @@ gem 'devise-i18n'
 gem 'devise-i18n-views'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'jquery-rails'
 

--- a/app/assets/javascripts/post.js
+++ b/app/assets/javascripts/post.js
@@ -1,0 +1,51 @@
+$(document).on('turbolinks:load', function(){
+
+  function buildPost(post) {
+    var content = post.content ? `${ post.content }` : "";
+    var img = post.image.url ? `<img src= "${ post.image.url }" id="chat-message__image">` : "";
+    var html = `<div class="chat-message" data-id="${post.id}">
+                  <div class="chat-message__user">
+                    <p class="chat-message__user__name">
+                      ${post.name}
+                    </p>
+                    <p class="chat-message__user__date">
+                      ${post.date}
+                    </p>
+                  </div>
+                  <div class="chat-message__text">
+                    <p class="chat-message__content">
+                      ${content}
+                    </p>
+                    ${img} 
+                  </div>
+                </div>`
+  return html;
+  }
+
+  $('#new_post').on('submit', function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false,
+    })
+    .done(function(data){
+      var html = buildPost(data);
+      $('.chat-messages').append(html)
+      $("#new_post")[0].reset();
+      $('.chat-messages').animate({ scrollTop: $('.chat-messages')[0].scrollHeight });
+    })
+
+    .fail(function(){
+      alert('送信に失敗しました')
+    })
+    .always(function(data){
+      $('.send').prop('disabled', false);
+    })
+  })
+})

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -10,9 +10,12 @@ class PostsController < ApplicationController
   def create
     @post = @group.posts.new(post_params)
     if @post.save
-      redirect_to group_posts_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_posts_path(params[:group_id]), notice: 'メッセージが送信されました' }
+        format.json
+      end
     else
-      @posts = @group.posts.includes(:user)
+      @post = @group.posts.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'
       render :index
     end

--- a/app/views/posts/create.json.jbuilder
+++ b/app/views/posts/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.content @post.content
+json.image @post.image
+json.date @post.created_at.strftime("%Y/%m/%d %H:%M")
+json.name @post.user.name
+json.id @post.id


### PR DESCRIPTION
#what
リロードなしで送信したメッセージおよび画像を表示する。
送信ボタンを連続で押せるようにする。
任意の範囲で自動でスクロールさせる。

#why
メッセージの送信をより簡略化するため。

以下プレビュー
①テキスト連続送信
https://gyazo.com/23624de400a9bc6141aa159ce30d6c01

②画像連続送信
https://gyazo.com/9e00b5b917690bfe2ec149a0e4f36291

③テキストと画像同時に送信、スクロール確認
https://gyazo.com/72421d86e7e67aebc667afdf078d93c7